### PR TITLE
:sparkles: Add routes for creating and reading comments under a post

### DIFF
--- a/backend/src/routes/v1/comments.ts
+++ b/backend/src/routes/v1/comments.ts
@@ -1,0 +1,89 @@
+import { Comment, Post } from '@/models';
+import type { Variables } from '@/types';
+import { zValidator } from '@hono/zod-validator';
+import { Hono } from 'hono';
+import { z } from 'zod';
+
+export const CommentRoutes = new Hono<{ Variables: Variables }>();
+
+// Create a comment under a post
+CommentRoutes.post(
+  '/posts/:postId/comments',
+  zValidator(
+    'json',
+    z.object({
+      content: z.string().min(1).max(65536),
+    }),
+  ),
+  zValidator(
+    'param',
+    z.object({
+      postId: z.string(),
+    }),
+  ),
+  async c => {
+    const { content } = c.req.valid('json');
+    const { postId } = c.req.valid('param');
+    const { userId } = c.get('user');
+
+    const post = await Post.findById(postId);
+
+    if (!post) {
+      return c.json({ error: 'Post not found' }, 404);
+    }
+
+    const comment = await Comment.create({
+      content,
+      post: post._id,
+      user: userId,
+    });
+
+    return c.json({ message: 'Comment created', comment: comment.clean() });
+  },
+);
+
+// Get all comments under a post, sortable by creation date or by votes
+CommentRoutes.get(
+  '/posts/:postId/comments',
+  zValidator(
+    'param',
+    z.object({
+      postId: z.string(),
+    }),
+  ),
+  zValidator(
+    'query',
+    z.object({
+      sort: z.enum(['asc', 'desc']).default('desc'),
+      sortBy: z.enum(['createdAt', 'votes']).default('createdAt'),
+      limit: z.number().int().min(1).max(100).default(10),
+      skip: z.number().int().min(0).default(0),
+    }),
+  ),
+  async c => {
+    const { postId } = c.req.valid('param');
+    const { sort, sortBy, limit, skip } = c.req.valid('query');
+
+    const post = await Post.findById(postId);
+
+    if (!post) {
+      return c.json({ error: 'Post not found' }, 404);
+    }
+
+    const comments = await Comment.aggregate([
+      { $match: { post: post._id } },
+      {
+        $addFields: {
+          votes: { $subtract: ['$upvotes', '$downvotes'] },
+        },
+      },
+      { $sort: { [sortBy]: sort === 'asc' ? 1 : -1 } },
+      { $skip: skip },
+      { $limit: limit },
+    ]);
+
+    comments.forEach(comment => delete comment.__v);
+
+    return c.json(comments);
+  },
+);

--- a/backend/src/routes/v1/index.ts
+++ b/backend/src/routes/v1/index.ts
@@ -2,8 +2,10 @@ import type { Variables } from '@/types';
 import { Hono } from 'hono';
 import { ChamberRoutes } from './chambers';
 import { PostRoutes } from './posts';
+import { CommentRoutes } from './comments';
 
 export const V1Routes = new Hono<{ Variables: Variables }>();
 
 V1Routes.route('/', ChamberRoutes);
 V1Routes.route('/', PostRoutes);
+V1Routes.route('/', CommentRoutes);


### PR DESCRIPTION
Add routes for creating and reading comments under a post.

* **New Route for Creating Comments:**
  - Add a new route in `backend/src/routes/v1/comments.ts` for creating comments under a post.
  - Validate the request body and parameters using `zod`.
  - Check if the post exists before creating a comment.
  - Return a success message with the created comment.

* **New Route for Reading Comments:**
  - Add a new route in `backend/src/routes/v1/comments.ts` for reading all comments under a post.
  - Validate the request parameters and query using `zod`.
  - Sort comments by creation date or votes.
  - Return the sorted comments.

* **Update Index Routes:**
  - Import the new comment routes in `backend/src/routes/v1/index.ts`.
  - Add the new comment routes to `V1Routes`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/emanuele-toma/echochamber/pull/1?shareId=7d44cc3a-e84f-4e88-97fe-412640748b51).